### PR TITLE
Fixes ARM vs x86 logic error & ChromeOS no longer has wget

### DIFF
--- a/docs/installers/chromebook.sh
+++ b/docs/installers/chromebook.sh
@@ -49,7 +49,7 @@ cd ~/Downloads;
 
 echo "Great! Let's get to it then.";
 echo "Downloading crouton...";
-wget https://goo.gl/fd3zc -O crouton;
+curl -Ls https://goo.gl/fd3zc > crouton;
 echo "crouton downloaded.";
 
 echo "Detecting architecture...";

--- a/docs/installers/chromebook.sh
+++ b/docs/installers/chromebook.sh
@@ -65,10 +65,10 @@ echo "Architecture detected as ${ARCH}...";
 echo "Preparing xenial chroot with XIWI (you will be prompted for a root password.  You can use crouton to encrypt the chroot later if you wish.)..."
 chmod +x ./crouton;
 if [ "$ARCH" = "arm64" ]; then
-  sudo sh ./crouton -t xiwi -n code-oss-chroot;
-else
   echo "Chroot will be created as armhf. This will be changed later when Electron introduces 64-bit ARM support...";
   sudo sh ./crouton -t xiwi -a armhf -n code-oss-chroot;
+else
+  sudo sh ./crouton -t xiwi -n code-oss-chroot;
 fi;
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
There has always been a logic error when looking for an "ARM" processor.

If you have ARM it runs the x86 code
and if you have x86 it runs the ARM code.
BOTH fail.

ALSO since chromeOS 66 or 67 we've lost wget and we only have the "curl" command.

Both fixes are in this PR. 