### PR TITLE
wget is not available on ChromeOS <=66

### DIFF
--- a/docs/installers/chromebook.sh
+++ b/docs/installers/chromebook.sh
@@ -49,7 +49,7 @@ cd ~/Downloads;
 
 echo "Great! Let's get to it then.";
 echo "Downloading crouton...";
-wget https://goo.gl/fd3zc -O crouton;
+curl https://goo.gl/fd3zc -L -o crouton;
 echo "crouton downloaded.";
 
 echo "Detecting architecture...";


### PR DESCRIPTION
using curl with -L option due to the http redirect inside the cruton short link