### PR TITLE
Replace wget by curl

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@ image_url: images/code.png
   <li>Press Ctrl + Alt + T to enter the crosh shell.</li>
   <li>Type shell and press return to enter the developer shell.</li>
   <li>Enter the following command, then press return:</li>
-  <pre id="install-yum">. <( wget -O - https://code.headmelted.com/installers/chromebook.sh )</pre>
+  <pre id="install-yum">. <( curl https://code.headmelted.com/installers/chromebook.sh )</pre>
   </li>
 </ol></div>
 </section>


### PR DESCRIPTION
`wget` isn't available on the latest Chromebook version.