### PR TITLE
Update developer mode link in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@ image_url: images/code.png
   <h2><strong><i class="fa fa-cube"></i>&nbsp;Crouton method</strong></h2>
 <p>The instructions below require you to put your device into Developer Mode.  <strong>There are important security implications to doing this, so please consider the ramifications carefully before deciding to do so.  Please click <a href="http://www.chromium.org/chromium-os/chromiumos-design-docs/developer-mode">here</a> for more details.</strong></p>
 <ol>
-  <li>Put your Chromebook into <a href="https://www.chromium.org/chromium-os/poking-around-your-chrome-os-device">developer mode</a>.</li>
+  <li>Put your Chromebook into <a href="https://chromium.googlesource.com/chromiumos/docs/+/master/developer_mode.md">developer mode</a>.</li>
   <li>Install the <a href="https://goo.gl/OVQOEt">crouton extension</a> from the Chrome Web Store.</li>
   <li>Press Ctrl + Alt + T to enter the crosh shell.</li>
   <li>Type shell and press return to enter the developer shell.</li>


### PR DESCRIPTION
Looks like the page on developer mode has moved. This change updates to the new url. Hope this helps 👍

Thanks!